### PR TITLE
Enable to ignore `<unk>` token in training

### DIFF
--- a/src/language_modeling_with_boxes/datasets/utils.py
+++ b/src/language_modeling_with_boxes/datasets/utils.py
@@ -121,6 +121,7 @@ def get_iter_on_device(
     data_device,
     add_pad,
     eos_mask,
+    ignore_unk,
 ):
     print("Loading VOCAB & Tokenized Training files ...")
     vocab_stoi, vocab_freq = load_vocab("./data/" + dataset)
@@ -163,6 +164,7 @@ def get_iter_on_device(
         eos_mask=eos_mask,
         device=data_device,
         batch_size=batch_size,
+        ignore_unk=ignore_unk,
     )
 
     val_iter, test_iter = None, None

--- a/src/language_modeling_with_boxes/train/__main__.py
+++ b/src/language_modeling_with_boxes/train/__main__.py
@@ -116,8 +116,15 @@ class IntOrPercent(click.ParamType):
 )
 @click.option(
     "--lang",
+    type=str,
     default="en",
     help="en or ja",
+)
+@click.option(
+    "--ignore_unk",
+    type=bool,
+    default=False,
+    help="Ignore <unk> token in training if True",
 )
 
 ######  Training parameters #########

--- a/src/language_modeling_with_boxes/train/train.py
+++ b/src/language_modeling_with_boxes/train/train.py
@@ -38,6 +38,7 @@ def training(config):
         config["data_device"],
         config["add_pad"],
         config["eos_mask"],
+        config["ignore_unk"],
     )
 
     if config["model_type"] == "Word2Box":


### PR DESCRIPTION
If `--ignore_unk=True`, you can train ignoring <unk> token like <pad> token.