### PR TITLE
Breaking away from legacy codes

### DIFF
--- a/src/language_modeling_with_boxes/datasets/word2vecgpu.py
+++ b/src/language_modeling_with_boxes/datasets/word2vecgpu.py
@@ -13,7 +13,7 @@ class Word2VecDatasetOnDevice(Dataset):
         self,
         corpus: LongTensor,
         window_size: int = 10,
-        vocab: Union[Dict, Any] = None,
+        vocab: Dict = None,
         subsample_thresh: float = 1e-3,
         eos_mask: bool = True,
         device: Union[int, str] = None,
@@ -24,15 +24,15 @@ class Word2VecDatasetOnDevice(Dataset):
         self.vocab = vocab
         self.subsample_thresh = subsample_thresh
         self.eos_mask = eos_mask
-        self.pad_id = torch.tensor(self.vocab.stoi["<pad>"]).to(self.corpus.device)
-        self.eos_token = torch.tensor(self.vocab.stoi["<eos>"]).to(self.corpus.device)
+        self.pad_id = torch.tensor(self.vocab["stoi"]["<pad>"]).to(self.corpus.device)
+        self.eos_token = torch.tensor(self.vocab["stoi"]["<eos>"]).to(self.corpus.device)
         self.ignore_unk = ignore_unk
-        self.unk_token = torch.tensor(self.vocab.stoi["<unk>"]).to(self.corpus.device)
+        self.unk_token = torch.tensor(self.vocab["stoi"]["<unk>"]).to(self.corpus.device)
         # pad this at the beginning and end with window_size number of padding
         self.pad_size = 10
-        total_words = sum(self.vocab.freqs.values())
+        total_words = sum(self.vocab["freqs"].values())
         unigram_prob = (
-            torch.tensor([self.vocab.freqs.get(key, 0) for key in self.vocab.itos])
+            torch.tensor([self.vocab["freqs"].get(key, 0) for key in self.vocab["itos"]])
             / total_words
         )
         self.subsampling_prob = 1.0 - torch.sqrt(

--- a/src/language_modeling_with_boxes/train/Trainer.py
+++ b/src/language_modeling_with_boxes/train/Trainer.py
@@ -46,12 +46,12 @@ class Trainer:
         self.n_gram = n_gram
         self.lr = lr
         self.vocab = vocab
-        self.vocab_size = len(self.vocab.itos)
+        self.vocab_size = len(self.vocab["itos"])
         self.negative_samples = negative_samples
         self.log_frequency = log_frequency
-        self.vocab.freqs["<pad>"] = 0  # Don't want to negaive sample pads.
+        self.vocab["freqs"]["<pad>"] = 0  # Don't want to negaive sample pads.
         sorted_freqs = torch.tensor(
-            [self.vocab.freqs.get(key, 0) for key in self.vocab.itos]
+            [self.vocab["freqs"].get(key, 0) for key in self.vocab["itos"]]
         )
         self.sampling = torch.pow(sorted_freqs, 0.75)
         self.sampling = self.sampling / torch.sum(self.sampling)
@@ -317,9 +317,6 @@ class TrainerWordSimilarity(Trainer):
             writer.add_scalar("loss", row.losses, row.epoch)
             writer.add_scalar("test_score", row.test_scores, row.epoch)
 
-        # Logging embeddings
-        # writer.add_embedding(model.embeddings_word.weight, self.vocab.itos, global_step=epoch+1, tag="embeddings_word")
-
         writer.close()
 
         print("Model trained.")
@@ -347,16 +344,16 @@ class TrainerWordSimilarity(Trainer):
                         row[0] = row[0].lower()
                         row[1] = row[1].lower()
                         if (
-                            self.vocab.stoi.get(row[0], "<unk>") != "<unk>"
-                            and self.vocab.stoi.get(row[1], "<unk>") != "<unk>"
+                            self.vocab["stoi"].get(row[0], "<unk>") != "<unk>"
+                            and self.vocab["stoi"].get(row[1], "<unk>") != "<unk>"
                         ):
                             word1 = (
-                                torch.tensor(self.vocab.stoi[row[0]], dtype=int)
+                                torch.tensor(self["vocab"].stoi[row[0]], dtype=int)
                                 .unsqueeze(0)
                                 .to(self.device)
                             )
                             word2 = (
-                                torch.tensor(self.vocab.stoi[row[1]], dtype=int)
+                                torch.tensor(self.vocab["stoi"][row[1]], dtype=int)
                                 .unsqueeze(0)
                                 .to(self.device)
                             )

--- a/src/language_modeling_with_boxes/train/Trainer.py
+++ b/src/language_modeling_with_boxes/train/Trainer.py
@@ -348,7 +348,7 @@ class TrainerWordSimilarity(Trainer):
                             and self.vocab["stoi"].get(row[1], "<unk>") != "<unk>"
                         ):
                             word1 = (
-                                torch.tensor(self["vocab"].stoi[row[0]], dtype=int)
+                                torch.tensor(self.vocab["stoi"][row[0]], dtype=int)
                                 .unsqueeze(0)
                                 .to(self.device)
                             )

--- a/src/language_modeling_with_boxes/train/train.py
+++ b/src/language_modeling_with_boxes/train/train.py
@@ -5,7 +5,7 @@ import datetime, json, os
 from .Trainer import Trainer, TrainerWordSimilarity
 
 from ..models import Word2Box, Word2Vec, Word2VecPooled, Word2BoxConjunction, Word2Gauss
-from ..datasets.utils import get_iter_on_device
+from ..datasets.utils import get_vocab, get_train_iter
 
 import json
 
@@ -29,7 +29,9 @@ def training(config):
     torch.manual_seed(config["seed"])
     random.seed(config["seed"])
 
-    TEXT, train_iter, val_iter, test_iter, subsampling_prob = get_iter_on_device(
+    vocab = get_vocab(config["dataset"], config["eos_mask"])
+    vocab_size = len(vocab["stoi"])
+    train_iter = get_train_iter(
         config["batch_size"],
         config["dataset"],
         config["model_type"],
@@ -39,11 +41,13 @@ def training(config):
         config["add_pad"],
         config["eos_mask"],
         config["ignore_unk"],
+        vocab,
     )
+    val_iter = None
 
     if config["model_type"] == "Word2Box":
         model = Word2Box(
-            vocab_size=len(TEXT.stoi),
+            vocab_size=vocab_size,
             embedding_dim=config["embedding_dim"],
             batch_size=config["batch_size"],
             n_gram=config["n_gram"],
@@ -55,7 +59,7 @@ def training(config):
 
     elif config["model_type"] == "Word2Vec":
         model = Word2Vec(
-            vocab_size=len(TEXT.stoi),
+            vocab_size=vocab_size,
             embedding_dim=config["embedding_dim"],
             batch_size=config["batch_size"],
             n_gram=config["n_gram"],
@@ -63,7 +67,7 @@ def training(config):
 
     elif config["model_type"] == "Word2VecPooled":
         model = Word2VecPooled(
-            vocab_size=len(TEXT.stoi),
+            vocab_size=vocab_size,
             embedding_dim=config["embedding_dim"],
             batch_size=config["batch_size"],
             n_gram=config["n_gram"],
@@ -71,7 +75,7 @@ def training(config):
         )
     elif config["model_type"] == "Word2BoxConjunction":
         model = Word2BoxConjunction(
-            vocab_size=len(TEXT.stoi),
+            vocab_size=vocab_size,
             embedding_dim=config["embedding_dim"],
             batch_size=config["batch_size"],
             n_gram=config["n_gram"],
@@ -81,7 +85,7 @@ def training(config):
         )
     elif config["model_type"] == "Word2Gauss":
         model = Word2Gauss(
-            vocab_size=len(TEXT.stoi),
+            vocab_size=vocab_size,
             embedding_dim=config["embedding_dim"],
             batch_size=config["batch_size"],
             n_gram=config["n_gram"],
@@ -97,7 +101,7 @@ def training(config):
         trainer = TrainerWordSimilarity(
             train_iter=train_iter,
             val_iter=val_iter,
-            vocab=TEXT,
+            vocab=vocab,
             lr=config["lr"],
             n_gram=config["n_gram"],
             lang=config["lang"],
@@ -120,7 +124,7 @@ def training(config):
         trainer = TrainerWordSimilarity(
             train_iter=train_iter,
             val_iter=val_iter,
-            vocab=TEXT,
+            vocab=vocab,
             lr=config["lr"],
             n_gram=config["n_gram"],
             lang=config["lang"],


### PR DESCRIPTION
In `torchtext>=0.9.0`, `Field()` is no longer supported. 
Please see [here](https://github.com/pytorch/text/blob/master/examples/legacy_tutorial/migration_tutorial.ipynb)